### PR TITLE
Calendar re-showing after being hid

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -649,6 +649,9 @@
         },
 
         updateView: function() {
+        	// Only update view if the calendar is currently shown
+        	if (!this.isShowing) return;
+
             if (this.timePicker) {
                 this.renderTimePicker('left');
                 this.renderTimePicker('right');

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1544,7 +1544,7 @@
             if (this.isShowing) {
                 this.updateView();
             } else {
-                e.preventDefault();
+                e.stopPropagation();
             };
             
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -519,7 +519,7 @@
 
         if (this.element.is('input')) {
             this.element.on({
-                //'click.daterangepicker': $.proxy(this.show, this),
+                'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
                 'keyup.daterangepicker': $.proxy(this.elementChanged, this),
                 'keydown.daterangepicker': $.proxy(this.keydown, this)
@@ -1543,6 +1543,8 @@
             // Only update view if the calendar is currently shown
             if (this.isShowing) {
                 this.updateView();
+            } else {
+                e.preventDefault();
             };
             
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -519,7 +519,7 @@
 
         if (this.element.is('input')) {
             this.element.on({
-                'click.daterangepicker': $.proxy(this.show, this),
+                //'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
                 'keyup.daterangepicker': $.proxy(this.elementChanged, this),
                 'keydown.daterangepicker': $.proxy(this.keydown, this)
@@ -528,7 +528,7 @@
             if (this.parentEl === 'body') {
                 this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
             } else {
-                //this.element.on('click.daterangepicker', $.proxy(this.show, this));
+                this.element.on('click.daterangepicker', $.proxy(this.show, this));
             }
         }
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -649,8 +649,8 @@
         },
 
         updateView: function() {
-        	// Only update view if the calendar is currently shown
-        	if (!this.isShowing) return;
+            // Only update view if the calendar is currently shown
+            if (!this.isShowing) return;
 
             if (this.timePicker) {
                 this.renderTimePicker('left');

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -649,9 +649,6 @@
         },
 
         updateView: function() {
-            // Only update view if the calendar is currently shown
-            if (!this.isShowing) return;
-
             if (this.timePicker) {
                 this.renderTimePicker('left');
                 this.renderTimePicker('right');
@@ -1543,7 +1540,11 @@
                     this.clickApply();
             }
 
-            this.updateView();
+            // Only update view if the calendar is currently shown
+            if (this.isShowing) {
+                this.updateView();
+            };
+            
 
             if (this.selectionType === 'drag')
                 return false;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -528,7 +528,7 @@
             if (this.parentEl === 'body') {
                 this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
             } else {
-                this.element.on('click.daterangepicker', $.proxy(this.show, this));
+                //this.element.on('click.daterangepicker', $.proxy(this.show, this));
             }
         }
 


### PR DESCRIPTION
When using this component as a popup date picker (not inline), the popup should be hidden upon selecting a date, but it gets shown again - `updateView` calls `show`, and also the click event propagates up to a parent `on` which shows it again. Neither of these should happen in this case (click event on a date, and date picker is hidden).

Tested that popup is properly hidden after clicking on a date.